### PR TITLE
Refactor HdfsRsync test header

### DIFF
--- a/src/main/scala/org/wikimedia/analytics/hdfstools/HdfsRsyncConfig.scala
+++ b/src/main/scala/org/wikimedia/analytics/hdfstools/HdfsRsyncConfig.scala
@@ -22,8 +22,6 @@ import org.apache.hadoop.fs.permission.ChmodParser
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.log4j.{Appender, Level}
 
-import scala.util.matching.Regex
-
 
 /**
  * Configuration class for Hdfs Rsync
@@ -309,9 +307,10 @@ case class HdfsRsyncConfig(
     }
 
     /**
-     *
-     * @param filterRule
-     * @return
+     * Parse a filter rule into an HdfsRsyncFilterRule, the scala object allowing to
+     * apply the rule on paths.
+     * @param filterRule the filter rule to parse
+     * @return the created HdfsRsyncFilterRule
      */
     def getParsedFilterRule(filterRule: String): HdfsRsyncFilterRule = {
         filterRule match {
@@ -355,7 +354,7 @@ case class HdfsRsyncConfig(
             chmodFiles = getChmodParser(chmodCommands, files = true),
             chmodDirs = getChmodParser(chmodCommands, files = false),
 
-            parsedFilterRules =
+            parsedFilterRules = filterRules.map(getParsedFilterRule)
         )
     }
 }

--- a/src/test/scala/org/wikimedia/analytics/hdfstools/TestHdfsRsyncConfig.scala
+++ b/src/test/scala/org/wikimedia/analytics/hdfstools/TestHdfsRsyncConfig.scala
@@ -2,16 +2,8 @@ package org.wikimedia.analytics.hdfstools
 
 import java.net.URI
 
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
 
-
-class TestHdfsRsyncConfig extends AnyFlatSpec with Matchers with BeforeAndAfterEach with TestHdfsRsyncHelper {
-
-    override def beforeEach(): Unit = helperBefore()
-
-    override def afterEach(): Unit = helperAfter()
+class TestHdfsRsyncConfig extends TestHdfsRsyncHelper {
 
     "HdfsRsyncConfig" should "validate src URI" in {
         // Invalid cases

--- a/src/test/scala/org/wikimedia/analytics/hdfstools/TestHdfsRsyncExec.scala
+++ b/src/test/scala/org/wikimedia/analytics/hdfstools/TestHdfsRsyncExec.scala
@@ -6,16 +6,9 @@ import java.nio.file.attribute.{PosixFileAttributes, PosixFilePermissions}
 import java.nio.file.{Files, Paths}
 
 import org.apache.log4j.Level
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
 
 
-class TestHdfsRsyncExec extends AnyFlatSpec with Matchers with BeforeAndAfterEach with TestHdfsRsyncHelper {
-
-    override def beforeEach(): Unit = helperBefore()
-
-    override def afterEach(): Unit = helperAfter()
+class TestHdfsRsyncExec extends TestHdfsRsyncHelper {
 
     // Reused values
     val tmpDstBaseFile = new File(tmpDstBase)

--- a/src/test/scala/org/wikimedia/analytics/hdfstools/TestHdfsRsyncFilterRule.scala
+++ b/src/test/scala/org/wikimedia/analytics/hdfstools/TestHdfsRsyncFilterRule.scala
@@ -1,0 +1,12 @@
+package org.wikimedia.analytics.hdfstools
+
+
+class TestHdfsRsyncFilterRule extends TestHdfsRsyncHelper {
+
+    "HdfsRsyncFilterRule" should "match simple patterns or not" in {
+
+
+    }
+
+}
+

--- a/src/test/scala/org/wikimedia/analytics/hdfstools/TestHdfsRsyncHelper.scala
+++ b/src/test/scala/org/wikimedia/analytics/hdfstools/TestHdfsRsyncHelper.scala
@@ -6,9 +6,12 @@ import java.net.URI
 import org.apache.commons.io.FileUtils
 import org.apache.log4j.AppenderSkeleton
 import org.apache.log4j.spi.LoggingEvent
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 
-trait TestHdfsRsyncHelper {
+trait TestHdfsRsyncHelper extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
     /**
      * Custom log appender allowing tests to get access to messages logged during execution
@@ -76,14 +79,14 @@ trait TestHdfsRsyncHelper {
     }
 
 
-    def helperBefore(): Unit = {
+    override def beforeEach(): Unit = {
         // In case there are leftovers
         deleteTestFiles()
         testLogAppender.reset()
 
         createTestFiles()
     }
-     def helperAfter(): Unit = {
+     override def afterEach(): Unit = {
          deleteTestFiles()
          testLogAppender.reset()
      }


### PR DESCRIPTION
The test classes now only extend the helper, itself extending the needed
classes and implementing beforeEach and afterEach