### PR TITLE
Fix hdfs-rsync bug and tests

### DIFF
--- a/src/main/scala/org/wikimedia/analytics/hdfstools/HdfsRsyncExec.scala
+++ b/src/main/scala/org/wikimedia/analytics/hdfstools/HdfsRsyncExec.scala
@@ -325,7 +325,7 @@ class HdfsRsyncExec(config: HdfsRsyncConfig) {
         } else if (areDifferent(src, existingTarget.get)) {
             if (!config.ignoreExisting) {
                 // If config.update is true, copy only if src is newer than dst
-                if (!config.update || approxCompareTimestamps(src, existingTarget.get) < 0) {
+                if (!config.update || approxCompareTimestamps(src, existingTarget.get) > 0) {
                     Some(copy(src, target, isUpdate = true))
                 } else {
                     skip("update")

--- a/src/test/scala/org/wikimedia/analytics/hdfstools/TestHdfsRsyncHelper.scala
+++ b/src/test/scala/org/wikimedia/analytics/hdfstools/TestHdfsRsyncHelper.scala
@@ -100,10 +100,16 @@ trait TestHdfsRsyncHelper extends AnyFlatSpec with Matchers with BeforeAndAfterE
         create(tmpSrc2File3, 19000L, isDir = false)
         create(tmpSrc2Folder2, 18000L, isDir = true)
         create(tmpSrc2Folder2File4, 17000L, isDir = false)
+        // Force some wait time between interactions with the filesystem.
+        // This prevents files accessed-time issues that make tests fail
+        Thread.sleep(10)
     }
 
     def deleteTestFiles(): Unit = {
         FileUtils.deleteDirectory(new File(testBaseURI))
+        // Force some wait time between interactions with the filesystem.
+        // This prevents files accessed-time issues that make tests fail
+        Thread.sleep(10)
     }
 
     override def beforeEach(): Unit = {


### PR DESCRIPTION
 - bug was in 'update' mode, where the source file would be copied
   if older than the destination file, instead of younger.
 - Tests were failing eratically due to many filesystem IO operations
   in too small time. Adding some waiting time fixes the issue.